### PR TITLE
Retry three times before giving up with No image message

### DIFF
--- a/src/scripts/shinchoku.coffee
+++ b/src/scripts/shinchoku.coffee
@@ -12,10 +12,18 @@ request = require 'request'
 cheerio = require 'cheerio'
 
 url = 'http://shinchokudodesuka.tumblr.com/random'
+retries = 3
 
 module.exports = (robot) ->
   robot.hear /(shinchoku|進捗)/i, (msg) ->
-    request url: url, (err, res, body) ->
-      $ = cheerio.load body
-      imgUrl = $('#posts > div.photo img').attr 'src'
-      msg.send imgUrl or 'No Image'
+    post_shinchoku = (retry_left) ->
+      request url: url, (err, res, body) ->
+        $ = cheerio.load body
+        imgUrl = $('#posts > div.photo img').attr 'src'
+        if imgUrl
+          msg.send imgUrl
+        else if not retry_left
+          msg.send 'No Image'
+        else
+          post_shinchoku retry_left-1
+    post_shinchoku retries


### PR DESCRIPTION
分散システムの常として、エラーの発生は例外的状況ではない。進捗画像が表示されないことによる影響を少なくするため、「No Image」を出力する前に3回リトライすることを提案する。